### PR TITLE
Added some miscellaneous missing xmldocs

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
@@ -5,7 +5,7 @@ namespace Discord
     public interface IGuildIntegration
     {
         /// <summary> Gets the integration ID. </summary>
-        /// <returns> A unique identifier value of this integration. </returns>
+        /// <returns> The unique identifier value of this integration. </returns>
         ulong Id { get; }
         /// <summary> Gets the integration name. </summary>
         /// <returns> A string containing the name of this integration. </returns>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
@@ -5,7 +5,7 @@ namespace Discord
     public interface IGuildIntegration
     {
         /// <summary> Gets the integration ID. </summary>
-        /// <returns> The unique identifier value of this integration. </returns>
+        /// <returns> An <see cref="ulong"/> representing the unique identifier value of this integration. </returns>
         ulong Id { get; }
         /// <summary> Gets the integration name. </summary>
         /// <returns> A string containing the name of this integration. </returns>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
@@ -18,6 +18,12 @@ namespace Discord
         bool IsEnabled { get; }
         /// <summary> Gets if this integration is syncing or not. </summary>
         /// <returns> A value indicating if this integration is syncing. </returns>
+        /// <remarks>
+        ///     An integration with syncing enabled will update it's "subscribers" on
+        ///     an interval, while one with syncing disabled will not.
+        ///     A user must manually choose when sync the integration
+        ///     if syncing is disabled.
+        /// </remarks>
         bool IsSyncing { get; }
         /// <summary> Gets the ID that this integration uses for "subscribers". </summary>
         ulong ExpireBehavior { get; }

--- a/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
@@ -21,7 +21,7 @@ namespace Discord
         bool IsSyncing { get; }
         /// <summary> Gets the ID that this integration uses for "subscribers". </summary>
         ulong ExpireBehavior { get; }
-        /// <summary> Gets the grace period before expiring subscribers. </summary>
+        /// <summary> Gets the grace period before expiring "subscribers". </summary>
         ulong ExpireGracePeriod { get; }
         /// <summary> Gets when this integration was last synced. </summary>
         /// <returns> A <see cref="DateTimeOffset"/> containing a date and time of day when the integration was last synced. </returns>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
@@ -5,35 +5,30 @@ namespace Discord
     public interface IGuildIntegration
     {
         /// <summary> Gets the integration ID. </summary>
-        /// <returns> Gets the integration ID. </returns>
+        /// <returns> A unique identifier value of this integration. </returns>
         ulong Id { get; }
         /// <summary> Gets the integration name. </summary>
-        /// <returns> Gets the integration name. </returns>
+        /// <returns> A string containing the name of this integration. </returns>
         string Name { get; }
         /// <summary> Gets the integration type (twitch, youtube, etc). </summary>
-        /// <returns> Gets the integration type (twitch, youtube, etc). </returns>
+        /// <returns> A string containing the name of the type of integration. </returns>
         string Type { get; }
         /// <summary> Gets if this integration is enabled or not. </summary>
-        /// <summary> Gets if this integration is enabled or not. </returns>
+        /// <summary> A value indicating if this integration is enabled. </returns>
         bool IsEnabled { get; }
         /// <summary> Gets if this integration is syncing or not. </summary>
-        /// <returns> Gets if this integration is syncing or not. </returns>
+        /// <returns> A value indicating if this integration is syncing. </returns>
         bool IsSyncing { get; }
         /// <summary> Gets the ID that this integration uses for "subscribers". </summary>
-        /// <returns> Gets the ID that this integration uses for "subscribers". </returns>
         ulong ExpireBehavior { get; }
         /// <summary> Gets the grace period before expiring subscribers. </summary>
-        /// <returns> Gets the grace period before expiring subscribers. </returns>
         ulong ExpireGracePeriod { get; }
         /// <summary> Gets when this integration was last synced. </summary>
-        /// <returns> Gets when this integration was last synced. </returns>
+        /// <returns> A <see cref="DateTimeOffset"/> containing a date and time of day when the integration was last synced. </returns>
         DateTimeOffset SyncedAt { get; }
         /// <summary>
         ///     Gets integration account information. See <see cref="IntegrationAccount"/>.
         /// </summary>
-        /// <returns>
-        ///     Gets integration account information. See <see cref="IntegrationAccount"/>.
-        /// </returns>
         IntegrationAccount Account { get; }
 
         IGuild Guild { get; }

--- a/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
@@ -1,17 +1,44 @@
-﻿using System;
+using System;
 
 namespace Discord
 {
     public interface IGuildIntegration
     {
+        /// <summary>
+        ///     The integration ID.
+        /// </summary>
         ulong Id { get; }
+        /// <summary>
+        ///     The integration name.
+        /// </summary>
         string Name { get; }
+        /// <summary>
+        ///     The integration type (twich, youtube, etc).
+        /// </summary>
         string Type { get; }
+        /// <summary>
+        ///     Is this integration enabled?
+        /// </summary>
         bool IsEnabled { get; }
+        /// <summary>
+        ///     Is this integration syncing?
+        /// </summary>
         bool IsSyncing { get; }
+        /// <summary>
+        ///     ID that this integration uses for "subscribers".
+        /// </summary>
         ulong ExpireBehavior { get; }
+        /// <summary>
+        ///     The grace period before expiring subscribers.
+        /// </summary>
         ulong ExpireGracePeriod { get; }
+        /// <summary>
+        ///     When this integration was last synced.
+        /// </summary>
         DateTimeOffset SyncedAt { get; }
+        /// <summary>
+        ///     Integration account information. See <see cref="IntegrationAccount"/>.
+        /// </summary>
         IntegrationAccount Account { get; }
 
         IGuild Guild { get; }

--- a/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
@@ -4,41 +4,36 @@ namespace Discord
 {
     public interface IGuildIntegration
     {
-        /// <summary>
-        ///     The integration ID.
-        /// </summary>
+        /// <summary> Gets the integration ID. </summary>
+        /// <returns> Gets the integration ID. </returns>
         ulong Id { get; }
-        /// <summary>
-        ///     The integration name.
-        /// </summary>
+        /// <summary> Gets the integration name. </summary>
+        /// <returns> Gets the integration name. </returns>
         string Name { get; }
-        /// <summary>
-        ///     The integration type (twich, youtube, etc).
-        /// </summary>
+        /// <summary> Gets the integration type (twitch, youtube, etc). </summary>
+        /// <returns> Gets the integration type (twitch, youtube, etc). </returns>
         string Type { get; }
-        /// <summary>
-        ///     Is this integration enabled?
-        /// </summary>
+        /// <summary> Gets if this integration is enabled or not. </summary>
+        /// <summary> Gets if this integration is enabled or not. </returns>
         bool IsEnabled { get; }
-        /// <summary>
-        ///     Is this integration syncing?
-        /// </summary>
+        /// <summary> Gets if this integration is syncing or not. </summary>
+        /// <returns> Gets if this integration is syncing or not. </returns>
         bool IsSyncing { get; }
-        /// <summary>
-        ///     ID that this integration uses for "subscribers".
-        /// </summary>
+        /// <summary> Gets the ID that this integration uses for "subscribers". </summary>
+        /// <returns> Gets the ID that this integration uses for "subscribers". </returns>
         ulong ExpireBehavior { get; }
-        /// <summary>
-        ///     The grace period before expiring subscribers.
-        /// </summary>
+        /// <summary> Gets the grace period before expiring subscribers. </summary>
+        /// <returns> Gets the grace period before expiring subscribers. </returns>
         ulong ExpireGracePeriod { get; }
-        /// <summary>
-        ///     When this integration was last synced.
-        /// </summary>
+        /// <summary> Gets when this integration was last synced. </summary>
+        /// <returns> Gets when this integration was last synced. </returns>
         DateTimeOffset SyncedAt { get; }
         /// <summary>
-        ///     Integration account information. See <see cref="IntegrationAccount"/>.
+        ///     Gets integration account information. See <see cref="IntegrationAccount"/>.
         /// </summary>
+        /// <returns>
+        ///     Gets integration account information. See <see cref="IntegrationAccount"/>.
+        /// </returns>
         IntegrationAccount Account { get; }
 
         IGuild Guild { get; }

--- a/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
@@ -27,7 +27,7 @@ namespace Discord
         /// <returns> A <see cref="DateTimeOffset"/> containing a date and time of day when the integration was last synced. </returns>
         DateTimeOffset SyncedAt { get; }
         /// <summary>
-        ///     Gets integration account information. See <see cref="IntegrationAccount"/>.
+        ///     Gets integration account information.
         /// </summary>
         IntegrationAccount Account { get; }
 

--- a/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuildIntegration.cs
@@ -19,7 +19,7 @@ namespace Discord
         /// <summary> Gets if this integration is syncing or not. </summary>
         /// <returns> A value indicating if this integration is syncing. </returns>
         /// <remarks>
-        ///     An integration with syncing enabled will update it's "subscribers" on
+        ///     An integration with syncing enabled will update its "subscribers" on
         ///     an interval, while one with syncing disabled will not.
         ///     A user must manually choose when sync the integration
         ///     if syncing is disabled.

--- a/src/Discord.Net.Core/Entities/Guilds/IntegrationAccount.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IntegrationAccount.cs
@@ -1,11 +1,17 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 namespace Discord
 {
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public struct IntegrationAccount
     {
+        /// <summary>
+        ///     ID of the account.
+        /// </summary>
         public string Id { get; }
+        /// <summary>
+        ///     Name of the account.
+        /// </summary>
         public string Name { get; private set; }
 
         public override string ToString() => Name;

--- a/src/Discord.Net.Core/Entities/Guilds/IntegrationAccount.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IntegrationAccount.cs
@@ -6,7 +6,7 @@ namespace Discord
     public struct IntegrationAccount
     {
         /// <summary> Gets the ID of the account. </summary>
-        /// <returns> The unique identifier of this integration account. </returns>
+        /// <returns> A <see cref="string"> unique identifier of this integration account. </returns>
         public string Id { get; }
         /// <summary> Gets the name of the account. </summary>
         /// <returns> A string containing the name of this integration account. </returns>

--- a/src/Discord.Net.Core/Entities/Guilds/IntegrationAccount.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IntegrationAccount.cs
@@ -6,10 +6,10 @@ namespace Discord
     public struct IntegrationAccount
     {
         /// <summary> Gets the ID of the account. </summary>
-        /// <returns> Gets the ID of the account. </returns>
+        /// <returns> The unique identifier of this integration account. </returns>
         public string Id { get; }
         /// <summary> Gets the name of the account. </summary>
-        /// <returns> Gets the name of the account. </returns>
+        /// <returns> A string containing the name of this integration account. </returns>
         public string Name { get; private set; }
 
         public override string ToString() => Name;

--- a/src/Discord.Net.Core/Entities/Guilds/IntegrationAccount.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IntegrationAccount.cs
@@ -5,13 +5,11 @@ namespace Discord
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public struct IntegrationAccount
     {
-        /// <summary>
-        ///     ID of the account.
-        /// </summary>
+        /// <summary> Gets the ID of the account. </summary>
+        /// <returns> Gets the ID of the account. </returns>
         public string Id { get; }
-        /// <summary>
-        ///     Name of the account.
-        /// </summary>
+        /// <summary> Gets the name of the account. </summary>
+        /// <returns> Gets the name of the account. </returns>
         public string Name { get; private set; }
 
         public override string ToString() => Name;

--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermission.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermission.cs
@@ -22,7 +22,7 @@ namespace Discord
         /// </summary>
         AddReactions		= 0x00_00_00_40,
         /// <summary>
-        ///             Allows for reading of messages. This flag is obsolete, use <see cref = "ViewChannel" /> instead.
+        ///     Allows for reading of messages. This flag is obsolete, use <see cref = "ViewChannel" /> instead.
         /// </summary>
         [Obsolete("Use ViewChannel instead.")]
         ReadMessages		= ViewChannel,

--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermission.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermission.cs
@@ -22,7 +22,7 @@ namespace Discord
         /// </summary>
         AddReactions		= 0x00_00_00_40,
         /// <summary>
-        ///     Allows for reading of message.
+        ///             Allows for reading of messages. This flag is obsolete, use <see cref = "ViewChannel" /> instead.
         /// </summary>
         [Obsolete("Use ViewChannel instead.")]
         ReadMessages		= ViewChannel,

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
@@ -14,23 +14,43 @@ namespace Discord
         /// <summary>
         ///     Allows kicking members.
         /// </summary>
+        /// <remarks>
+        ///     This permission requires the owner account to use two-factor
+        ///     authentication when used on a guild that has server-wide 2FA enabled.
+        /// </remarks>
         KickMembers			= 0x00_00_00_02,
         /// <summary>
         ///     Allows banning members.
         /// </summary>
-        BanMembers			= 0x00_00_00_04,
+        /// <remarks>
+        ///     This permission requires the owner account to use two-factor
+        ///     authentication when used on a guild that has server-wide 2FA enabled.
+        /// </remarks>
+        BanMembers          = 0x00_00_00_04,
         /// <summary>
         ///     Allows all permissions and bypasses channel permission overwrites.
         /// </summary>
-        Administrator		= 0x00_00_00_08,
+        /// <remarks>
+        ///     This permission requires the owner account to use two-factor
+        ///     authentication when used on a guild that has server-wide 2FA enabled.
+        /// </remarks>
+        Administrator       = 0x00_00_00_08,
         /// <summary>
         ///     Allows management and editing of channels.
         /// </summary>
-        ManageChannels		= 0x00_00_00_10,
+        /// <remarks>
+        ///     This permission requires the owner account to use two-factor
+        ///     authentication when used on a guild that has server-wide 2FA enabled.
+        /// </remarks>
+        ManageChannels      = 0x00_00_00_10,
         /// <summary>
         ///     Allows management and editing of the guild.
         /// </summary>
-        ManageGuild			= 0x00_00_00_20,
+        /// <remarks>
+        ///     This permission requires the owner account to use two-factor
+        ///     authentication when used on a guild that has server-wide 2FA enabled.
+        /// </remarks>
+        ManageGuild         = 0x00_00_00_20,
 
         // Text
 		/// <summary>
@@ -52,7 +72,11 @@ namespace Discord
         /// <summary>
         ///     Allows for deletion of other users messages.
         /// </summary>
-        ManageMessages		= 0x00_00_20_00,
+        /// <remarks>
+        ///     This permission requires the owner account to use two-factor
+        ///     authentication when used on a guild that has server-wide 2FA enabled.
+        /// </remarks>
+        ManageMessages      = 0x00_00_20_00,
         /// <summary>
         ///     Allows links sent by users with this permission will be auto-embedded.
         /// </summary>
@@ -114,14 +138,26 @@ namespace Discord
         /// <summary>
         ///     Allows management and editing of roles.
         /// </summary>
+        /// <remarks>
+        ///     This permission requires the owner account to use two-factor
+        ///     authentication when used on a guild that has server-wide 2FA enabled.
+        /// </remarks>
         ManageRoles         = 0x10_00_00_00,
         /// <summary>
         ///     Allows management and editing of webhooks.
         /// </summary>
+        /// <remarks>
+        ///     This permission requires the owner account to use two-factor
+        ///     authentication when used on a guild that has server-wide 2FA enabled.
+        /// </remarks>
         ManageWebhooks      = 0x20_00_00_00,
         /// <summary>
         ///     Allows management and editing of emojis.
         /// </summary>
+        /// <remarks>
+        ///     This permission requires the owner account to use two-factor
+        ///     authentication when used on a guild that has server-wide 2FA enabled.
+        /// </remarks>
         ManageEmojis        = 0x40_00_00_00
     }
 }

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
@@ -26,7 +26,7 @@ namespace Discord
         ///     This permission requires the owner account to use two-factor
         ///     authentication when used on a guild that has server-wide 2FA enabled.
         /// </remarks>
-        BanMembers          = 0x00_00_00_04,
+        BanMembers			= 0x00_00_00_04,
         /// <summary>
         ///     Allows all permissions and bypasses channel permission overwrites.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -244,8 +244,19 @@ namespace Discord
                 readMessageHistory, mentionEveryone, useExternalEmojis, connect, speak, muteMembers, deafenMembers, moveMembers,
                 useVoiceActivation, changeNickname, manageNicknames, manageRoles, manageWebhooks, manageEmojis);
 
+        /// <summary>
+        ///     Returns a value that indicates if a specific <see cref="GuildPermission"/> is enabled
+        ///     in these permissions.
+        /// </summary>
+        /// <param name="permission">The permission value to check for.</param>
+        /// <returns><c>true</c> if the permission is enabled, <c>false</c> otherwise.</returns>
         public bool Has(GuildPermission permission) => Permissions.GetValue(RawValue, permission);
 
+        /// <summary>
+        ///     Returns a <see cref="List{T}"/> containing all of the <see cref="GuildPermission"/>
+        ///     flags that are enabled.
+        /// </summary>
+        /// <returns>A <see cref="List{T}"/> containing <see cref="GuildPermission"/> flags. Empty if none are enabled.</returns>
         public List<GuildPermission> ToList()
         {
             var perms = new List<GuildPermission>();

--- a/src/Discord.Net.Core/Entities/Permissions/OverwritePermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/OverwritePermissions.cs
@@ -193,6 +193,10 @@ namespace Discord
                 embedLinks, attachFiles, readMessageHistory, mentionEveryone, useExternalEmojis, connect, speak, muteMembers, deafenMembers, 
                 moveMembers, useVoiceActivation, manageRoles, manageWebhooks);
 
+        /// <summary>
+        ///     Creates a <see cref="List{T}"/> of all the <see cref="ChannelPermission"/> values that are allowed.
+        /// </summary>
+        /// <returns>A <see cref="List{T}"/> of all allowed <see cref="ChannelPermission"/> flags. If none, the list will be empty.</returns>
         public List<ChannelPermission> ToAllowList()
         {
             var perms = new List<ChannelPermission>();
@@ -205,6 +209,11 @@ namespace Discord
             }
             return perms;
         }
+
+        /// <summary>
+        ///     Creates a <see cref="List{T}"/> of all the <see cref="ChannelPermission"/> values that are denied.
+        /// </summary>
+        /// <returns>A <see cref="List{T}"/> of all denied <see cref="ChannelPermission"/> flags. If none, the list will be empty.</returns>
         public List<ChannelPermission> ToDenyList()
         {
             var perms = new List<ChannelPermission>();

--- a/src/Discord.Net.Core/Entities/Roles/Color.cs
+++ b/src/Discord.Net.Core/Entities/Roles/Color.cs
@@ -75,6 +75,10 @@ namespace Discord
         public static readonly Color DarkerGrey = new Color(0x546E7A);
 
         /// <summary> Gets the encoded value for this color. </summary>
+        /// <remarks>
+        ///     This value is encoded as an unsigned integer value. The most-significant 8 bits contain the red value,
+        ///     the middle 8 bits contain the green value, and the least-significant 8 bits contain the blue value.
+        /// </remarks>
         public uint RawValue { get; }
 
         /// <summary> Gets the red component for this color. </summary>

--- a/src/Discord.Net.Core/Entities/Users/IConnection.cs
+++ b/src/Discord.Net.Core/Entities/Users/IConnection.cs
@@ -5,7 +5,7 @@ namespace Discord
     public interface IConnection
     {
         /// <summary> Gets the ID of the connection account. </summary>
-        /// <returns> The unique idenitifer of this connection. </returns>
+        /// <returns> A <see cref="string"/> representing the unique identifier value of this connection. </returns>
         string Id { get; }
         /// <summary> Gets the service of the connection (twitch, youtube). </summary>
         /// <returns> A string containing the name of this type of connection. </returns>
@@ -17,7 +17,10 @@ namespace Discord
         /// <returns> A value which if true indicates that this connection has been revoked, otherwise false. </returns>
         bool IsRevoked { get; }
         /// <summary> Gets a <see cref="IReadOnlyCollection{T}"/> of integration IDs. </summary>
-        /// <returns> An <see cref="IReadOnlyCollection{T}"/> containing the unique identifier values of integrations. </returns>
+        /// <returns>
+        ///     An <see cref="IReadOnlyCollection{T}"/> containing <see cref="ulong"/>
+        ///     representations of unique identifier values of integrations.
+        /// </returns>
         IReadOnlyCollection<ulong> IntegrationIds { get; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Users/IConnection.cs
+++ b/src/Discord.Net.Core/Entities/Users/IConnection.cs
@@ -4,26 +4,20 @@ namespace Discord
 {
     public interface IConnection
     {
-        /// <summary>
-        ///     ID of the connection account.
-        /// </summary>
+        /// <summary> Gets the ID of the connection account. </summary>
+        /// <returns> Gets the ID of the connection account. </returns>
         string Id { get; }
-        /// <summary>
-        ///     The service of the connection (twich, youtube).
-        /// </summary>
+        /// <summary> Gets the service of the connection (twitch, youtube). </summary>
+        /// <returns> Gets the service of the connection (twitch, youtube). </returns>
         string Type { get; }
-        /// <summary>
-        ///     The username of the connection account.
-        /// </summary>
+        /// <summary> Gets the username of the connection account. </summary>
+        /// <returns> Gets the username of the connection account. </returns>
         string Name { get; }
-        /// <summary>
-        ///     Whether the connection is revoked.
-        /// </summary>
+        /// <summary> Gets whether the connection is revoked. </summary>
+        /// <returns> Gets whether the connection is revoked. </returns>
         bool IsRevoked { get; }
-
-        /// <summary>
-        ///     A <see cref="IReadOnlyCollection{T}"/> of integration IDs.
-        /// </summary>
+        /// <summary> Gets a <see cref="IReadOnlyCollection{T}"/> of integration IDs. </summary>
+        /// <returns> Gets a <see cref="IReadOnlyCollection{T}"/> of integration IDs. </returns>
         IReadOnlyCollection<ulong> IntegrationIds { get; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Users/IConnection.cs
+++ b/src/Discord.Net.Core/Entities/Users/IConnection.cs
@@ -5,19 +5,19 @@ namespace Discord
     public interface IConnection
     {
         /// <summary> Gets the ID of the connection account. </summary>
-        /// <returns> Gets the ID of the connection account. </returns>
+        /// <returns> The unique idenitifer of this connection. </returns>
         string Id { get; }
         /// <summary> Gets the service of the connection (twitch, youtube). </summary>
-        /// <returns> Gets the service of the connection (twitch, youtube). </returns>
+        /// <returns> A string containing the name of this type of connection. </returns>
         string Type { get; }
         /// <summary> Gets the username of the connection account. </summary>
-        /// <returns> Gets the username of the connection account. </returns>
+        /// <returns> A string containing the name of this connection. </returns>
         string Name { get; }
         /// <summary> Gets whether the connection is revoked. </summary>
-        /// <returns> Gets whether the connection is revoked. </returns>
+        /// <returns> A value which if true indicates that this connection has been revoked, otherwise false. </returns>
         bool IsRevoked { get; }
         /// <summary> Gets a <see cref="IReadOnlyCollection{T}"/> of integration IDs. </summary>
-        /// <returns> Gets a <see cref="IReadOnlyCollection{T}"/> of integration IDs. </returns>
+        /// <returns> An <see cref="IReadOnlyCollection{T}"/> containing the unique identifier values of integrations. </returns>
         IReadOnlyCollection<ulong> IntegrationIds { get; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Users/IConnection.cs
+++ b/src/Discord.Net.Core/Entities/Users/IConnection.cs
@@ -1,14 +1,29 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Discord
 {
     public interface IConnection
     {
+        /// <summary>
+        ///     ID of the connection account.
+        /// </summary>
         string Id { get; }
+        /// <summary>
+        ///     The service of the connection (twich, youtube).
+        /// </summary>
         string Type { get; }
+        /// <summary>
+        ///     The username of the connection account.
+        /// </summary>
         string Name { get; }
+        /// <summary>
+        ///     Wheter the connection is revoked.
+        /// </summary>
         bool IsRevoked { get; }
 
+        /// <summary>
+        ///     A <see cref="IReadOnlyCollection{T}"/> of integration IDs.
+        /// </summary>
         IReadOnlyCollection<ulong> IntegrationIds { get; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Users/IConnection.cs
+++ b/src/Discord.Net.Core/Entities/Users/IConnection.cs
@@ -16,6 +16,7 @@ namespace Discord
         /// <summary> Gets whether the connection is revoked. </summary>
         /// <returns> A value which if true indicates that this connection has been revoked, otherwise false. </returns>
         bool IsRevoked { get; }
+
         /// <summary> Gets a <see cref="IReadOnlyCollection{T}"/> of integration IDs. </summary>
         /// <returns>
         ///     An <see cref="IReadOnlyCollection{T}"/> containing <see cref="ulong"/>

--- a/src/Discord.Net.Core/Entities/Users/IConnection.cs
+++ b/src/Discord.Net.Core/Entities/Users/IConnection.cs
@@ -17,7 +17,7 @@ namespace Discord
         /// </summary>
         string Name { get; }
         /// <summary>
-        ///     Wheter the connection is revoked.
+        ///     Whether the connection is revoked.
         /// </summary>
         bool IsRevoked { get; }
 


### PR DESCRIPTION
Adds some missing xmldocs that were missing on public classes and interfaces here and there.

I'm personally a bit unfamiliar with the Integration and Connection types, but I was able to use descriptions from the Discord API docs. I figure at least having the API description is better than no description at all.

Added some remarks for GuildPermission flags that indicate which permissions may require 2FA.

Added some missing xml doc descriptions for the Permissions#ToList methods.

Added some technical details for Color#RawValue in the remarks, which indicate how the bits are packed into this value. I figure because it is exposed publicly, there should be some documentation about what this value is.