### PR TITLE
Fix strange borders on main logo in Chrome and Firefox

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ title: Home
 
 # Discord.Net Documentation
 
-<img class="big-logo logo-switcher" />
+<div class="big-logo logo-switcher" />
 
 ## What is Discord.Net?
 


### PR DESCRIPTION
An img tag gets default styling in these browsers & acts strangely when a src isn't present, and since we switch the logo with css, this can just be a div. Tested & working with all themes in Chrome, Firefox & Edge.

![image](https://i.imgur.com/kfeheab.png)