### PR TITLE
Fixed a variable name copy pasta mistake

### DIFF
--- a/docs/guides/commands/samples/dependency-injection/dependency_module.cs
+++ b/docs/guides/commands/samples/dependency-injection/dependency_module.cs
@@ -32,6 +32,6 @@ public class DatabaseModule : ModuleBase<SocketCommandContext>
     [Command("read")]
     public async Task ReadFromDbAsync()
     {
-        await ReplyAsync(_database.GetData());
+        await ReplyAsync(DbService.GetData());
     }
 }


### PR DESCRIPTION
line 35 was _database.GetData() instead of DBService.GetData()


