### PR TITLE
docs: adjust wording of ActivityType.Watching enum

### DIFF
--- a/src/Discord.Net.Core/Entities/Activities/ActivityType.cs
+++ b/src/Discord.Net.Core/Entities/Activities/ActivityType.cs
@@ -18,7 +18,7 @@ namespace Discord
         /// </summary>
         Listening = 2,
         /// <summary>
-        ///     The user is watching a media.
+        ///     The user is watching some form of media.
         /// </summary>
         Watching = 3
     }


### PR DESCRIPTION
Adjusts the xmldoc summary wording of the ActivityType.Watching enum to fix a wording issue.